### PR TITLE
Use function `0x6` for single register writes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,9 @@ BINARY_TYPE = <pack format>
 VALUE = <number>
   The value to be written to the register. If not present, the register will be read instead.
 
+  If only one register is written to, the modbus function ``6 (0x6)``, "write single register" is used. 
+  If multiple registers are written to, the modbus function ``16 (0x10)``, "write multiple registers" is used.
+
 EXAMPLES
 ========
 

--- a/modbus_cli/access.py
+++ b/modbus_cli/access.py
@@ -180,7 +180,10 @@ class Access:
 
                 words.extend([h << 8 | l for h, l in grouper(struct.pack(pack_type, value), 2)])
 
-            message = modbus.protocol.write_multiple_registers(modbus.slave_id, self.address(), words)
+            if len(self.values_to_write) == 1:
+                message = modbus.protocol.write_single_register(modbus.slave_id, self.address(), words[0])
+            else:
+                message = modbus.protocol.write_multiple_registers(modbus.slave_id, self.address(), words)
 
         logging.debug('→ < %s >', dump(message))
 

--- a/modbus_cli/modbus_rtu.py
+++ b/modbus_cli/modbus_rtu.py
@@ -38,7 +38,7 @@ class ModbusRtu:
             response += self.connection.read(1)
             count = 2 + response[-1]
             response += self.connection.read(count)
-        elif function in (5, 15):
+        elif function in (5, 6, 15):
             # Function with fixed size
             response += self.connection.read(6)
         elif function & 0x80:


### PR DESCRIPTION
I wanted to use modbus-cli to talk to an air conditioner type system with an Enecon control board, but it doesn't support function 16 to write multiple registers. So this change makes modbus-cli use function 6 if only one register write is requested. Any attempt to write multiple registers still uses the multiple write call (16).

* use modbus function 6, `write_single_register`, if only one write requested
* use modbus function 16, `write_multiple_registers`, for multiple writes