### PR TITLE
Improve Modbus compatibility

### DIFF
--- a/modbus_cli/access.py
+++ b/modbus_cli/access.py
@@ -180,7 +180,7 @@ class Access:
 
                 words.extend([h << 8 | l for h, l in grouper(struct.pack(pack_type, value), 2)])
 
-            if len(self.values_to_write) == 1:
+            if len(words) == 1:
                 message = modbus.protocol.write_single_register(modbus.slave_id, self.address(), words[0])
             else:
                 message = modbus.protocol.write_multiple_registers(modbus.slave_id, self.address(), words)

--- a/modbus_cli/modbus_rtu.py
+++ b/modbus_cli/modbus_rtu.py
@@ -33,20 +33,22 @@ class ModbusRtu:
             raise RuntimeError('timeout')
         slave_id, function = response
 
-        if function in (1, 2, 3, 4):
-            # Functions with variable size
-            response += self.connection.read(1)
-            count = 2 + response[-1]
-            response += self.connection.read(count)
-        elif function in (5, 6, 15):
-            # Function with fixed size
-            response += self.connection.read(6)
-        elif function & 0x80:
-            response += self.connection.read(3)
-        else:
-            raise NotImplementedError('RTU function {}'.format(function))
-
-        logging.debug('← < %s > %s bytes', dump(response), len(response))
+        try:
+            if function in (1, 2, 3, 4):
+                # Functions with variable size
+                response += self.connection.read(1)
+                count = 2 + response[-1]
+                response += self.connection.read(count)
+            elif function in (5, 6, 15, 16):
+                # Function with fixed size
+                response += self.connection.read(6)
+            elif function & 0x80:
+                response += self.connection.read(3)
+            else:
+                response += self.connection.read(1024)
+                raise NotImplementedError('RTU function {}'.format(function))
+        finally:
+            logging.debug('← < %s > %s bytes', dump(response), len(response))
 
         return self.protocol.parse_response_adu(response, request)
 


### PR DESCRIPTION
- Fix writing multiple registers (e.g. "h@0/I=65536"), which was broken by #6.
- Add support for the response for Write Multiple Registers
- Always log response bytes before throwing exceptions (useful for debugging slaves that don't speak the protocol properly)