### PR TITLE
Implement proper stdout coloring, and add support for changing the serial timeout.

### DIFF
--- a/bin/modbus
+++ b/bin/modbus
@@ -5,12 +5,35 @@ import sys
 import os
 import logging
 
-import colorama
+import colorama as clr
 
 from modbus_cli.definitions import Definitions
 from modbus_cli.modbus_rtu import ModbusRtu
 from modbus_cli.modbus_tcp import ModbusTcp
 from modbus_cli.access import parse_accesses
+
+
+class ColourHandler(logging.Handler):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.formatter = logging.Formatter('%(style)s%(message)s'+clr.Style.RESET_ALL)
+
+    def emit(self, record):
+
+        if record.levelname == "DEBUG":
+            record.style = clr.Style.DIM
+        elif record.levelname == "WARNING":
+            record.style = clr.Style.BRIGHT
+        elif record.levelname == "ERROR":
+            record.style = clr.Style.BRIGHT+clr.Fore.RED
+        elif record.levelname == "CRITICAL":
+            record.style = clr.Style.BRIGHT+clr.Back.BLUE+clr.Fore.RED
+        else:
+            record.style = clr.Style.NORMAL
+
+        msg = self.format(record)
+
+        print(msg)
 
 
 def connect_to_device(args):
@@ -59,10 +82,20 @@ def main():
     parser.add_argument('access', nargs='+')
     args = parser.parse_args()
 
-    colorama.init()
+    clr.init()
     try:
+
+        mainLogger = logging.getLogger()            # Main logger
+
+
+
         if args.verbose:
-            logging.basicConfig(format=colorama.Style.DIM + '%(message)s' + colorama.Style.RESET_ALL, level=logging.DEBUG)
+            mainLogger.setLevel(logging.DEBUG)
+        else:
+            mainLogger.setLevel(logging.INFO)
+
+        ch = ColourHandler()
+        mainLogger.addHandler(ch)
 
         definitions = Definitions()
         definitions.parse(args.registers + os.environ.get('MODBUS_DEFINITIONS', '').split(':'))
@@ -71,6 +104,6 @@ def main():
 
     finally:
         # restore stdout/stderr if colorama has modified them (mostly on windows)
-        colorama.deinit()
+        clr.deinit()
 
 main()

--- a/bin/modbus
+++ b/bin/modbus
@@ -83,11 +83,9 @@ def main():
     args = parser.parse_args()
 
     clr.init()
+
     try:
-
         mainLogger = logging.getLogger()            # Main logger
-
-
 
         if args.verbose:
             mainLogger.setLevel(logging.DEBUG)
@@ -104,6 +102,7 @@ def main():
 
     finally:
         # restore stdout/stderr if colorama has modified them (mostly on windows)
+        # Leaving this out doesn't seem to hurt anything, but they say to call deinit, so we call deinit.
         clr.deinit()
 
 main()

--- a/bin/modbus
+++ b/bin/modbus
@@ -39,12 +39,12 @@ class ColourHandler(logging.Handler):
 def connect_to_device(args):
     if args.device[0] == '/':
         modbus = ModbusRtu(
-                device    = args.device,
-                baud      = args.baud,
-                parity    = args.parity,
+                device = args.device,
+                baud = args.baud,
+                parity = args.parity,
                 stop_bits = args.stop_bits,
-                slave_id  = args.slave_id,
-                timeout   = args.timeout
+                slave_id = args.slave_id,
+                timeout = args.timeout
             )
     else:
         port = 502

--- a/bin/modbus
+++ b/bin/modbus
@@ -39,12 +39,12 @@ class ColourHandler(logging.Handler):
 def connect_to_device(args):
     if args.device[0] == '/':
         modbus = ModbusRtu(
-                device = args.device,
-                baud = args.baud,
-                parity = args.parity,
-                stop_bits = args.stop_bits,
-                slave_id = args.slave_id,
-                timeout = args.timeout
+                device=args.device,
+                baud=args.baud,
+                parity=args.parity,
+                stop_bits=args.stop_bits,
+                slave_id=args.slave_id,
+                timeout=args.timeout
             )
     else:
         port = 502

--- a/bin/modbus
+++ b/bin/modbus
@@ -5,6 +5,8 @@ import sys
 import os
 import logging
 
+import colorama
+
 from modbus_cli.definitions import Definitions
 from modbus_cli.modbus_rtu import ModbusRtu
 from modbus_cli.modbus_tcp import ModbusTcp
@@ -13,7 +15,14 @@ from modbus_cli.access import parse_accesses
 
 def connect_to_device(args):
     if args.device[0] == '/':
-        modbus = ModbusRtu(args.device, args.baud, args.parity, args.stop_bits, args.slave_id)
+        modbus = ModbusRtu(
+                device    = args.device,
+                baud      = args.baud,
+                parity    = args.parity,
+                stop_bits = args.stop_bits,
+                slave_id  = args.slave_id,
+                timeout   = args.timeout
+            )
     else:
         port = 502
         parts = args.device.split(':')
@@ -45,17 +54,23 @@ def main():
     parser.add_argument('-p', '--stop-bits', type=int, default=1)
     parser.add_argument('-P', '--parity', choices=['e', 'o', 'n'], default='n')
     parser.add_argument('-v', '--verbose', action='store_true')
+    parser.add_argument('-t', '--timeout', type=float, default=5.0)
     parser.add_argument('device')
     parser.add_argument('access', nargs='+')
     args = parser.parse_args()
 
-    if args.verbose:
-        logging.basicConfig(format='\033[90m%(message)s\033[39m', level=logging.DEBUG)
+    colorama.init()
+    try:
+        if args.verbose:
+            logging.basicConfig(format=colorama.Style.DIM + '%(message)s' + colorama.Style.RESET_ALL, level=logging.DEBUG)
 
-    definitions = Definitions()
-    definitions.parse(args.registers + os.environ.get('MODBUS_DEFINITIONS', '').split(':'))
+        definitions = Definitions()
+        definitions.parse(args.registers + os.environ.get('MODBUS_DEFINITIONS', '').split(':'))
 
-    connect_to_device(args).perform_accesses(parse_accesses(args.access, definitions), definitions).close()
+        connect_to_device(args).perform_accesses(parse_accesses(args.access, definitions), definitions).close()
 
+    finally:
+        # restore stdout/stderr if colorama has modified them (mostly on windows)
+        colorama.deinit()
 
 main()

--- a/modbus_cli/access.py
+++ b/modbus_cli/access.py
@@ -79,7 +79,7 @@ class Access:
         for label, value, presenter in zip(self.labels(), self.values, self.presenters):
             if len(value) == 1:
                 value = value[0]
-            print('{}: {} {}'.format(label, value, self.present_value(value, presenter, definitions)))
+            logging.info('{}: {} {}'.format(label, value, self.present_value(value, presenter, definitions)))
 
     def present_value(self, value, presenter, definitions):
         if type(value) != int:

--- a/modbus_cli/modbus_rtu.py
+++ b/modbus_cli/modbus_rtu.py
@@ -4,10 +4,11 @@ from .access import dump
 
 
 class ModbusRtu:
-    def __init__(self, device, baud, parity, stop_bits, slave_id):
+    def __init__(self, device, baud, parity, stop_bits, slave_id, timeout):
         from serial import PARITY_EVEN, PARITY_ODD, PARITY_NONE
         parity_opts = { 'e': PARITY_EVEN, 'o': PARITY_ODD, 'n': PARITY_NONE }
         self.device = device
+        self.timeout = timeout
         self.baud = baud
         self.parity = parity_opts[parity]
         self.stop_bits = stop_bits
@@ -21,8 +22,16 @@ class ModbusRtu:
     def connect(self):
         from serial import Serial
 
+        logging.debug("Serial port %s. Parameters: %s baud, %s stop bit(s), parity: %s, timeout %ss.",
+                self.device,
+                self.baud,
+                self.stop_bits,
+                self.parity,
+                self.timeout,
+            )
+
         self.connection = Serial(port=self.device, baudrate=self.baud, parity=self.parity,
-                                 stopbits=self.stop_bits, bytesize=8, timeout=5)
+                                 stopbits=self.stop_bits, bytesize=8, timeout=self.timeout)
 
     def send(self, request):
         self.connection.write(request)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 umodbus
+colorama

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def readme():
 
 
 setup(name='modbus_cli',
-      version='0.1.5',
+      version='0.1.6',
       description='Command line tool to access Modbus devices',
       long_description=readme(),
       url='http://github.com/favalex/modbus-cli',
@@ -16,7 +16,7 @@ setup(name='modbus_cli',
       license='MPL 2.0',
       packages=['modbus_cli'],
       scripts=['bin/modbus'],
-      install_requires=['umodbus'],
+      install_requires=['umodbus', 'colorama'],
       zip_safe=False,
       classifiers=[
           'Development Status :: 4 - Beta',


### PR DESCRIPTION
Effectively this fixes the issues described in https://github.com/favalex/modbus-cli/issues/9 and https://github.com/favalex/modbus-cli/issues/8.

It also adds a custom logging handler so normal (e.g. logging.info() level log outputs) are printed normally, so all output should to through the logging interface in the future, if possible. 

It also has fancy logging.warning/error/critical output, which is nice. 

Color should also work on windows, which is a bonus.