### PR TITLE
Add --byte-order=mixed for mixed endian encoding

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -57,6 +57,7 @@ access
 -b BAUD, --baud=BAUD         Set the baud rate for serial connections.
 -p BITS, --stop-bits=BITS    Set the number of stop bits for serial connections.
 -P PARITY, --parity=PARITY   Set the parity for serial connections: (e)ven, (o)dd or (n)one
+-B ORDER, --byte-order ORDER Set the byte order to one of 'le' (little endian), 'be' (big endian) or 'mixed'
 -h, --help                   Show this help message and exit.
 
 ACCESS SYNTAX
@@ -100,7 +101,9 @@ BINARY_TYPE = <pack format>
   ``f`` 32 bits IEEE 754 float
   ===== ====
 
-  The default byte order is big-endian, use a ``<`` prefix in the format to specify little-endian.
+  The default byte order is big-endian.
+  To use little endian, use a ``<`` prefix, or ``--byte-order=le``.
+  To use mixed endian (little endian, but individual 16 bit registers are big endian), use ``--byte-order=mixed``.
 
 VALUE = <number>
   The value to be written to the register. If not present, the register will be read instead.

--- a/bin/modbus
+++ b/bin/modbus
@@ -78,6 +78,7 @@ def main():
     parser.add_argument('-P', '--parity', choices=['e', 'o', 'n'], default='n')
     parser.add_argument('-v', '--verbose', action='store_true')
     parser.add_argument('-t', '--timeout', type=float, default=5.0)
+    parser.add_argument('-B', '--byte-order', choices=['le', 'be', 'mixed'], default='be')
     parser.add_argument('device')
     parser.add_argument('access', nargs='+')
     args = parser.parse_args()
@@ -98,7 +99,7 @@ def main():
         definitions = Definitions()
         definitions.parse(args.registers + os.environ.get('MODBUS_DEFINITIONS', '').split(':'))
 
-        connect_to_device(args).perform_accesses(parse_accesses(args.access, definitions), definitions).close()
+        connect_to_device(args).perform_accesses(parse_accesses(args.access, definitions, args.byte_order), definitions).close()
 
     finally:
         # restore stdout/stderr if colorama has modified them (mostly on windows)

--- a/modbus_cli/access.py
+++ b/modbus_cli/access.py
@@ -177,6 +177,11 @@ class Access:
         else:
             words = []
 
+            if self.byte_order == 'mixed':
+                register_fmt = '<H'
+            else:
+                register_fmt = '>H'
+
             for pack_type, value in zip(self.pack_types, self.values_to_write):
                 n_bytes = struct.calcsize(pack_type)
                 assert n_bytes % 2 == 0
@@ -186,7 +191,10 @@ class Access:
                 else:
                     value = int(value, 0)
 
-                words.extend([h << 8 | l for h, l in grouper(struct.pack(pack_type, value), 2)])
+                words.extend([
+                    struct.unpack(register_fmt, bytes(byte_pair))[0]
+                    for byte_pair in grouper(struct.pack(pack_type, value), 2)
+                ])
 
             if len(words) == 1:
                 message = modbus.protocol.write_single_register(modbus.slave_id, self.address(), words[0])


### PR DESCRIPTION
Took me a while but finally got around to implement this https://github.com/favalex/modbus-cli/issues/1

This takes advantage of the fact that umodbus gives us big-endian-unpacked words already. So implementing mixed endian reuses the step that repacked those to bytes, but instead of repacking as big endian again, it uses little endian, effectively byte swapping each register. 

Then, a few lines below, it unpacks the bytes as little endian again, which means that 16 bit registers become exactly the same as what we got from umodbus at first, but 32/64 bit registers look very different.

```python
self.values.append(struct.unpack(pack, packed[:size]))
```

That line is outside of the diff because it didn't require changes. The "pack" variable is little endian thanks to this part of the code in parse_access:

```python
    if pack_type[0] not in '@=<>!':
        if byte_order in ('le', 'mixed'):
            pack_type = '<' + pack_type
        elif byte_order == 'be':
            pack_type = '!' + pack_type
```

This implies that the user can still do per-register endianness overrides, so you can theoretically do the inverse type of mixed endian if you really want to. But the main point of that is to still keep the old way of specifying endianness working. Personally I think it's more convenient to specify endianness as globally as a commandline option does, and not encode it in every register specification.

From my manual testing this also works with 64 bit fields, doubles in my case:

```
$ modbus -B mixed 10.69.42.108:503 'i@0/4d' 'i@0/12H'
Parsed 0 registers definitions from 1 files
0: (0.6900000000000001, 560.0, 560.0, -25.991)
0: (44565, 57671, 5242, 16358, 0, 0, 32768, 16513, 0, 0, 32768, 16513)
```