### PR TITLE
Add support for IPv6

### DIFF
--- a/bin/modbus
+++ b/bin/modbus
@@ -4,6 +4,7 @@ import argparse
 import sys
 import os
 import logging
+import urllib.parse
 
 import colorama as clr
 
@@ -16,18 +17,17 @@ from modbus_cli.access import parse_accesses
 class ColourHandler(logging.Handler):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.formatter = logging.Formatter('%(style)s%(message)s'+clr.Style.RESET_ALL)
+        self.formatter = logging.Formatter("%(style)s%(message)s" + clr.Style.RESET_ALL)
 
     def emit(self, record):
-
         if record.levelname == "DEBUG":
             record.style = clr.Style.DIM
         elif record.levelname == "WARNING":
             record.style = clr.Style.BRIGHT
         elif record.levelname == "ERROR":
-            record.style = clr.Style.BRIGHT+clr.Fore.RED
+            record.style = clr.Style.BRIGHT + clr.Fore.RED
         elif record.levelname == "CRITICAL":
-            record.style = clr.Style.BRIGHT+clr.Back.BLUE+clr.Fore.RED
+            record.style = clr.Style.BRIGHT + clr.Back.BLUE + clr.Fore.RED
         else:
             record.style = clr.Style.NORMAL
 
@@ -37,30 +37,23 @@ class ColourHandler(logging.Handler):
 
 
 def connect_to_device(args):
-    if args.device[0] == '/':
+    if args.device[0] == "/":
         modbus = ModbusRtu(
-                device=args.device,
-                baud=args.baud,
-                parity=args.parity,
-                stop_bits=args.stop_bits,
-                slave_id=args.slave_id,
-                timeout=args.timeout
-            )
+            device=args.device,
+            baud=args.baud,
+            parity=args.parity,
+            stop_bits=args.stop_bits,
+            slave_id=args.slave_id,
+            timeout=args.timeout,
+        )
     else:
-        port = 502
-        parts = args.device.split(':')
-        if len(parts) == 2:
-            host, port = parts
-        elif len(parts) == 1:
-            host = parts[0]
-        else:
+        try:
+            result = urllib.parse.urlsplit("//" + args.device)
+            host = result.hostname or "localhost"
+            port = result.port or 502
+        except ValueError:
             logging.error("Invalid device %r", args.device)
             sys.exit(1)
-
-        if host == '':
-            host = 'localhost'
-
-        port = int(port)
 
         modbus = ModbusTcp(host, port, args.slave_id)
 
@@ -71,23 +64,25 @@ def connect_to_device(args):
 
 def main():
     parser = argparse.ArgumentParser()
-    parser.add_argument('-r', '--registers', action='append', default=[])
-    parser.add_argument('-s', '--slave-id', type=int)
-    parser.add_argument('-b', '--baud', type=int, default=19200)
-    parser.add_argument('-p', '--stop-bits', type=int, default=1)
-    parser.add_argument('-P', '--parity', choices=['e', 'o', 'n'], default='n')
-    parser.add_argument('-v', '--verbose', action='store_true')
-    parser.add_argument('-S', '--silent', action='store_true')
-    parser.add_argument('-t', '--timeout', type=float, default=5.0)
-    parser.add_argument('-B', '--byte-order', choices=['le', 'be', 'mixed'], default='be')
-    parser.add_argument('device')
-    parser.add_argument('access', nargs='+')
+    parser.add_argument("-r", "--registers", action="append", default=[])
+    parser.add_argument("-s", "--slave-id", type=int)
+    parser.add_argument("-b", "--baud", type=int, default=19200)
+    parser.add_argument("-p", "--stop-bits", type=int, default=1)
+    parser.add_argument("-P", "--parity", choices=["e", "o", "n"], default="n")
+    parser.add_argument("-v", "--verbose", action="store_true")
+    parser.add_argument("-S", "--silent", action="store_true")
+    parser.add_argument("-t", "--timeout", type=float, default=5.0)
+    parser.add_argument(
+        "-B", "--byte-order", choices=["le", "be", "mixed"], default="be"
+    )
+    parser.add_argument("device")
+    parser.add_argument("access", nargs="+")
     args = parser.parse_args()
 
     clr.init()
 
     try:
-        mainLogger = logging.getLogger()            # Main logger
+        mainLogger = logging.getLogger()  # Main logger
 
         if args.verbose:
             mainLogger.setLevel(logging.DEBUG)
@@ -98,13 +93,19 @@ def main():
         mainLogger.addHandler(ch)
 
         definitions = Definitions(args.silent)
-        definitions.parse(args.registers + os.environ.get('MODBUS_DEFINITIONS', '').split(':'))
+        definitions.parse(
+            args.registers + os.environ.get("MODBUS_DEFINITIONS", "").split(":")
+        )
 
-        connect_to_device(args).perform_accesses(parse_accesses(args.access, definitions, args.byte_order, args.silent), definitions).close()
+        connect_to_device(args).perform_accesses(
+            parse_accesses(args.access, definitions, args.byte_order, args.silent),
+            definitions,
+        ).close()
 
     finally:
         # restore stdout/stderr if colorama has modified them (mostly on windows)
         # Leaving this out doesn't seem to hurt anything, but they say to call deinit, so we call deinit.
         clr.deinit()
+
 
 main()


### PR DESCRIPTION
Use `urllib.parse.urlsplit` to parse hostname + port, defaulting to `localhost:502`. Use `socket.getaddrinfo` to determine the suitable address family, an then attempt to connect for every returned addrinfo.

This implementation is compatible with previous behavior for IPv4 hosts, but it enables connecting to IPv6 hosts as well. Examples of device arguments that were previously supported and are still supported:

- `localhost`
- `localhost:502`
- `example.com`
- `example:502`
- `192.0.2.1`
- `192.0.2.1:502`

Examples of device arguments that are newly supported:

- `"[2001:db8::1]"`
- `"[2001:db8::1]:502"`
- `"[fe80::1%eth0]"`
- `"[fe80::1%eth0]:502"`

In addition, IPv6-only hosts with hostnames that could only be resolved via IPv6 are now also supported.