### PR TITLE
Added support for passing register address in HEX form

### DIFF
--- a/modbus_cli/access.py
+++ b/modbus_cli/access.py
@@ -278,7 +278,7 @@ def parse_access(register, name, write, value, byte_order, silent):
     else:
         pack_type = pack_type[1:]
 
-    address = int(address)
+    address = int(address, 0)
 
     if pack_type[0] not in '@=<>!':
         if byte_order in ('le', 'mixed'):

--- a/modbus_cli/definitions.py
+++ b/modbus_cli/definitions.py
@@ -1,7 +1,7 @@
 import re
 import logging
 
-REGISTER_RE = re.compile(r'([cCdhHi]@)?(\d+)(/[^:|]*)?([:|].*)?')
+REGISTER_RE = re.compile(r'^([cCdhHi]@)?(\d+)(/[^:|]*)?([:|].*)?$')
 
 
 class Definitions:

--- a/modbus_cli/definitions.py
+++ b/modbus_cli/definitions.py
@@ -25,7 +25,7 @@ class Definitions:
                             self.parse_line(accumulated_line)
                             accumulated_line = line
                     self.parse_line(accumulated_line)
-        if not self.silent: 
+        if not self.silent:
             logging.info('Parsed %d registers definitions from %d files', len(self.registers), len(filenames))
 
     def parse_line(self, line):

--- a/modbus_cli/definitions.py
+++ b/modbus_cli/definitions.py
@@ -1,7 +1,7 @@
 import re
 import logging
 
-REGISTER_RE = re.compile(r'^([cCdhHi]@)?(\d+)(/[^:|]*)?([:|].*)?$')
+REGISTER_RE = re.compile(r'^([cCdhHi]@)?(\d+|0x[0-9a-fA-F]+)(/[^:|]*)?([:|].*)?$')
 
 
 class Definitions:

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -47,6 +47,17 @@ class TestAccess(unittest.TestCase):
         self.assertEqual(':STATUS', it.presenter())
         self.assertEqual(4, it.size())
 
+    def test_full_hex(self):
+        it = parse_accesses(['i@0xa12B/<4H:STATUS'], None)
+        self.assertEqual(1, len(it))
+
+        it = it[0]
+        self.assertEqual('i', it.modbus_type)
+        self.assertEqual(0xa12b, it.address())
+        self.assertEqual('<4H', it.pack_type())
+        self.assertEqual(':STATUS', it.presenter())
+        self.assertEqual(4, it.size())
+
     def test_grouping(self):
         it = parse_accesses(['123', '124'], None)
         self.assertEqual(1, len(it))

--- a/tests/test_definitions.py
+++ b/tests/test_definitions.py
@@ -1,22 +1,25 @@
 import unittest
 import logging
+import os
 
 from modbus_cli.definitions import Definitions
 
 logging.basicConfig(level=logging.DEBUG)
+
+script_dir = os.path.dirname(os.path.realpath(__file__))
 
 
 class TestDefinitions(unittest.TestCase):
 
     def test_parse(self):
         it = Definitions(False)
-        it.parse(['tests/simple.modbus'])
+        it.parse([os.path.join(script_dir, 'simple.modbus')])
         self.assertEqual({'a_register': 'i@100/4H:a_presenter'}, it.registers)
         self.assertEqual({':a_presenter': {0: 'x', 1: 'y'}}, it.presenters)
 
     def test_parse_silent(self):
         it = Definitions(True)
-        it.parse(['tests/simple.modbus'])
+        it.parse([os.path.join(script_dir, 'simple.modbus')])
         self.assertEqual({'a_register': 'i@100/4H:a_presenter'}, it.registers)
         self.assertEqual({':a_presenter': {0: 'x', 1: 'y'}}, it.presenters)
 


### PR DESCRIPTION
Often register addresses are presented in datasheets in a hex form, added support for accesses like `0x0002/H=0x0602`

also a minor change in tests code, to make them work simply via right click -> `Run` in PyCharm.