### PR TITLE
Support installation of modbus CLI script under Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+venv
+__pycache__/
+*.egg-info/

--- a/modbus/__init__.py
+++ b/modbus/__init__.py
@@ -108,4 +108,3 @@ def main():
         clr.deinit()
 
 
-main()

--- a/modbus/__main__.py
+++ b/modbus/__main__.py
@@ -1,0 +1,6 @@
+from . import main
+
+
+if __name__ == '__main__':
+    main()
+

--- a/setup.py
+++ b/setup.py
@@ -15,8 +15,12 @@ setup(name='modbus_cli',
       author='Gabriele Favalessa',
       author_email='favalex@gmail.com',
       license='MPL 2.0',
-      packages=['modbus_cli'],
-      scripts=['bin/modbus'],
+      packages=['modbus', 'modbus_cli'],
+      entry_points={
+          'console_scripts': [
+              'modbus=modbus:main'
+          ],
+      },
       install_requires=['umodbus', 'colorama'],
       zip_safe=False,
       classifiers=[


### PR DESCRIPTION
This pull request slightly modifies the source code tree structure (it turns the `bin/modbus` script into a `modbus` module) and updates the `setup.py` to enable installation under Linux and Windows.